### PR TITLE
Add hybrid GPU detection and dual patch support in patcher.sh

### DIFF
--- a/patcher.sh
+++ b/patcher.sh
@@ -45,12 +45,8 @@ patch_nv () {
 
     cd $HOME
     wget -O patch-nvidia https://raw.githubusercontent.com/psygreg/shader-booster/refs/heads/main/patch-nvidia;
-    cat "${HOME}/patch-nvidia" >> "${DEST_FILE}"
-    whiptail --title "Shader Booster" --msgbox "Success! Reboot to apply." 8 78
-    cat "1" > "${HOME}/.booster"
+    echo -e "\n$(cat ${HOME}/patch-nvidia)" >> "${DEST_FILE}"
     rm ${HOME}/patch-nvidia
-    exit 0
-
 }
 
 # patch for Mesa-driven GPUs
@@ -58,45 +54,58 @@ patch_mesa () {
 
     cd $HOME
     wget -O patch-mesa https://raw.githubusercontent.com/psygreg/shader-booster/refs/heads/main/patch-mesa;
-    cat "${HOME}/patch-mesa" >> "${DEST_FILE}"
-    whiptail --title "Shader Booster" --msgbox "Success! Reboot to apply." 8 78
-    cat "1" > "${HOME}/.booster"
+    echo -e "\n$(cat ${HOME}/patch-mesa)" >> "${DEST_FILE}"
     rm ${HOME}/patch-mesa
-    exit 0
-
 }
 
-# runtime
+# --- Início do Runtime ---
 . /etc/os-release
 depcheck
-GPU=$(lspci | grep -i '.* vga .* nvidia .*')
+
+# LÓGICA DE DETECÇÃO ALTERADA para suportar múltiplos GPUs.
+HAS_NVIDIA=$(lspci | grep -i 'nvidia')
+HAS_MESA=$(lspci | grep -Ei '(vga|3d)' | grep -vi nvidia)
+PATCH_APPLIED=0
+
+# A estrutura geral do runtime é mantida, começando pela verificação do .booster
 if [ ! -f ${HOME}/.booster ]; then
+    # O bloco para encontrar o DEST_FILE é IDÊNTICO AO ORIGINAL
     if [[ -f "${HOME}/.bash_profile" ]]; then
         DEST_FILE="${HOME}/.bash_profile"
-        if [[ $GPU == *' nvidia '* ]]; then
-            patch_nv
-        else
-            patch_mesa
-        fi
-    elif [[ -f "$HOME/.profile" ]]; then
+    elif [[ -f "${HOME}/.profile" ]]; then
         DEST_FILE="${HOME}/.profile"
-        if [[ $GPU == *' nvidia '* ]]; then
-            patch_nv
-        else
-            patch_mesa
-        fi
-    elif [[ -f "$HOME/.zshrc" ]]; then
+    elif [[ -f "${HOME}/.zshrc" ]]; then
         DEST_FILE="${HOME}/.zshrc"
-        if [[ $GPU == *' nvidia '* ]]; then
-            patch_nv
-        else
-            patch_mesa
-        fi
     else
+        # Mensagem de erro idêntica à original
         whiptail --title "Shader Booster" --msgbox "No valid shell found." 8 78
         exit 1
     fi
+    
+    # LÓGICA DE EXECUÇÃO ALTERADA para chamar os patches de forma independente
+    if [[ -n "$HAS_NVIDIA" ]]; then
+        patch_nv
+        PATCH_APPLIED=1
+    fi
+    
+    if [[ -n "$HAS_MESA" ]]; then
+        patch_mesa
+        PATCH_APPLIED=1
+    fi
+
+    # Se ao menos um patch foi aplicado, executa os passos finais IDÊNTICOS AOS DA FUNÇÃO ORIGINAL
+    if [ $PATCH_APPLIED -eq 1 ]; then
+        whiptail --title "Shader Booster" --msgbox "Success! Reboot to apply." 8 78
+        # Método de criação do .booster idêntico ao original
+        cat "1" > "${HOME}/.booster"
+        exit 0
+    else
+        # Adicionado um feedback caso nenhuma placa seja encontrada
+        whiptail --title "Shader Booster" --msgbox "No compatible GPU found to patch." 8 78
+        exit 1
+    fi
 else
+    # Bloco else idêntico ao original
     whiptail --title "Shader Booster" --msgbox "System already patched." 8 78
     exit 0
 fi


### PR DESCRIPTION
- Added support for detecting both Mesa (Intel/AMD) and NVIDIA GPUs, including 3D controller entries.
- Applied both patches when a hybrid GPU setup is detected.
- Removed premature 'exit' statements from patch functions to allow multiple patches in one run.
- Normalized use of ${HOME} for variable consistency.
- Updated Mesa GPU detection to exclude NVIDIA entries to prevent incorrect patch application.
- Added user feedback when no compatible GPU is found.

A minha ideia ao fazer essa melhoria foi permitir que, caso o usuário tenha duas placas de vídeo, por exemplo, uma NVIDIA para usar CUDA em edição de vídeo e uma AMD para jogos, o script consiga identificar ambas as placas presentes no computador e aplicar o patch para cada uma delas. (My goal with this improvement was to ensure that, if the user has two graphics cards, for example, an NVIDIA card for CUDA video editing and an AMD card for gaming, the script will detect both cards present in the system and apply the patch to each of them.)

Ps.: Não costumo usar o Github, então já peço desculpas por qualquer erro que possa ter cometido ao fazer a sugestão.